### PR TITLE
feat: Add "Save and create another" option

### DIFF
--- a/src/components/Layout/NewItem/__test__/NewTaskForm.test.tsx
+++ b/src/components/Layout/NewItem/__test__/NewTaskForm.test.tsx
@@ -55,7 +55,7 @@ describe('NewTaskForm', () => {
       await userEvent.click(screen.getByRole('textbox', { name: 'Priority' }));
       await userEvent.click(screen.getByRole('option', { name: 'Low' }));
 
-      const submitButton = screen.getByRole('button', { name: 'Save Task' });
+      const submitButton = screen.getByTestId('save-button-basics');
       await userEvent.click(submitButton);
 
       expect(addTaskMock).toHaveBeenCalledWith(
@@ -82,7 +82,7 @@ describe('NewTaskForm', () => {
       const projectInput = screen.getByRole('textbox', { name: 'Project' });
       await userEvent.type(projectInput, 'Test Project');
 
-      const submitButton = screen.getByRole('button', { name: 'Save Task' });
+      const submitButton = screen.getByTestId('save-button-basics');
       await userEvent.click(submitButton);
 
       expect(addTaskMock).toHaveBeenCalledWith(
@@ -109,7 +109,7 @@ describe('NewTaskForm', () => {
       const descriptionInput = screen.getByRole('textbox', { name: 'Description' });
       await userEvent.type(descriptionInput, 'This is a test task description.');
 
-      const submitButton = screen.getByRole('button', { name: 'Save Task' });
+      const submitButton = screen.getByTestId('save-button-advanced');
       await userEvent.click(submitButton);
 
       expect(addTaskMock).toHaveBeenCalledWith(
@@ -119,6 +119,54 @@ describe('NewTaskForm', () => {
         })
       );
     }, 7000); // The runner is pretty slow in github, so we increase the timeout
+
+    it('Saves a task and keeps the form open to create another', async () => {
+      const handleClose = vi.fn();
+      const dataSource = getDataSource();
+
+      renderWithDataSource(<NewTaskForm handleClose={handleClose} />, dataSource);
+
+      const titleInput = screen.getByRole('textbox', { name: 'Title' });
+      await userEvent.type(titleInput, 'First Task');
+
+      // Click the save options dropdown
+      const saveOptions = screen.getByTestId('save-options-basics');
+      await userEvent.click(saveOptions);
+
+      // Click the "Save and create another" button
+      const saveAndCreateAnotherButton = screen.getByTestId('save-and-create-another-basics');
+      await userEvent.click(saveAndCreateAnotherButton);
+
+      // The first task should be saved
+      expect(addTaskMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'First Task',
+        })
+      );
+
+      // The form should be reset
+      expect(titleInput).toHaveValue('');
+
+      // The modal should still be open
+      expect(handleClose).not.toHaveBeenCalled();
+
+      // Enter a second task
+      await userEvent.type(titleInput, 'Second Task');
+      const submitButton = screen.getByTestId('save-button-basics');
+      await userEvent.click(submitButton);
+
+      // The second task should be saved
+      expect(addTaskMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Second Task',
+        })
+      );
+
+      // The modal should be closed
+      await waitFor(() => {
+        expect(handleClose).toHaveBeenCalled();
+      });
+    });
   });
 
   it('Blurs the active element when the form is submitted', async () => {
@@ -179,7 +227,7 @@ describe('NewTaskForm', () => {
     const recurrenceDaySelect = screen.getByRole('radio', { name: 'Tues' });
     await userEvent.click(recurrenceDaySelect);
 
-    const submitButton = screen.getByRole('button', { name: 'Save Task' });
+    const submitButton = screen.getByTestId('save-button-advanced');
     await userEvent.click(submitButton);
 
     expect(addTaskMock).toHaveBeenCalledWith(
@@ -219,7 +267,7 @@ describe('NewTaskForm', () => {
     await userEvent.clear(recurrenceDaySelect);
     await userEvent.type(recurrenceDaySelect, '15');
 
-    const submitButton = screen.getByRole('button', { name: 'Save Task' });
+    const submitButton = screen.getByTestId('save-button-advanced');
     await userEvent.click(submitButton);
 
     expect(addTaskMock).toHaveBeenCalledWith(
@@ -263,7 +311,7 @@ describe('NewTaskForm', () => {
     const recurrenceDaySelect = screen.getByRole('radio', { name: 'Sun' });
     await userEvent.click(recurrenceDaySelect);
 
-    const submitButton = screen.getByRole('button', { name: 'Save Task' });
+    const submitButton = screen.getByTestId('save-button-advanced');
     await userEvent.click(submitButton);
 
     expect(addTaskMock).toHaveBeenCalledWith(

--- a/src/components/Tasks/TaskForm.tsx
+++ b/src/components/Tasks/TaskForm.tsx
@@ -2,13 +2,16 @@ import dayjs from 'dayjs';
 import { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 import {
+  ActionIcon,
   Box,
   Button,
+  ButtonGroup,
   Chip,
   Fieldset,
   Flex,
   FocusTrap,
   Group,
+  Menu,
   NumberInput,
   Paper,
   Radio,
@@ -26,6 +29,7 @@ import {
 import { DatePickerInput } from '@mantine/dates';
 import { UseFormReturnType } from '@mantine/form';
 import { useHotkeys, useOs } from '@mantine/hooks';
+import { IconChevronDown } from '@tabler/icons-react';
 import sharedStyle from '@/components/style.module.css';
 import {
   NewTask,
@@ -46,10 +50,12 @@ export default function TaskForm({
   form,
   handleSubmit,
   isNewTask,
+  handleSaveAndCreateAnother,
 }: {
   form: UseFormReturnType<TaskFormType>;
   handleSubmit: () => void;
   isNewTask: boolean;
+  handleSaveAndCreateAnother?: () => void;
 }) {
   const [activeTab, setActiveTab] = useState<string | null>('basics');
   const [newNoteText, setNewNoteText] = useState<string>('');
@@ -147,6 +153,39 @@ export default function TaskForm({
 
   const pluralizeInterval = form.values.recurrence?.interval === 1;
 
+  const saveButton = (tabName: 'basics' | 'advanced') => (
+    <Group mt={20}>
+      <ButtonGroup>
+        <Button type="submit" data-testid={`save-button-${tabName}`}>
+          Save Task
+        </Button>
+        {isNewTask && (
+          <Menu>
+            <Menu.Target>
+              <ActionIcon
+                variant="filled"
+                color="blue"
+                size="lg"
+                aria-label="Save options"
+                data-testid={`save-options-${tabName}`}
+              >
+                <IconChevronDown size={14} />
+              </ActionIcon>
+            </Menu.Target>
+            <Menu.Dropdown>
+              <Menu.Item
+                onClick={handleSaveAndCreateAnother}
+                data-testid={`save-and-create-another-${tabName}`}
+              >
+                Save and create another
+              </Menu.Item>
+            </Menu.Dropdown>
+          </Menu>
+        )}
+      </ButtonGroup>
+    </Group>
+  );
+
   return (
     <form onSubmit={form.onSubmit(handleSubmit)}>
       <FocusTrap>
@@ -213,9 +252,7 @@ export default function TaskForm({
                 searchable
               />
 
-              <Button type="submit" mt={20}>
-                Save Task
-              </Button>
+              {saveButton('basics')}
             </Stack>
           </Tabs.Panel>
 
@@ -345,9 +382,7 @@ export default function TaskForm({
                 </Box>
               </Box>
 
-              <Button type="submit" mt={20}>
-                Save Task
-              </Button>
+              {saveButton('advanced')}
             </Stack>
           </Tabs.Panel>
 


### PR DESCRIPTION
This change adds a dropdown to the save button on the new task form, giving users the option to "Save and create another".

When "Save and create another" is selected, the task is saved, and the new task form is cleared, allowing the user to immediately enter another task without closing the dialog.

- Replaced the single save button with a Mantine `ButtonGroup` containing a primary save button and a menu with the new option.
- Added a `handleSaveAndCreateAnother` function to `NewTaskForm.tsx` to handle the new logic.
- Refactored the saving logic to be reusable.
- Added a new test case to `NewTaskForm.test.tsx` to cover the new functionality.
- Updated existing tests to use unique `data-testid`s for the save buttons to prevent conflicts.