### PR TITLE
feat: Add custom coefficients to urgency calculation

### DIFF
--- a/src/components/Settings/CoefficientsForm.tsx
+++ b/src/components/Settings/CoefficientsForm.tsx
@@ -1,5 +1,17 @@
 import React from 'react';
-import { Button, NumberInput, SimpleGrid, Stack } from '@mantine/core';
+import { IconTrash } from '@tabler/icons-react';
+import {
+  ActionIcon,
+  Box,
+  Button,
+  Group,
+  NumberInput,
+  Select,
+  SimpleGrid,
+  Stack,
+  TextInput,
+  Title,
+} from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { usePreferencesRepository } from '@/contexts/DataSourceContext';
 import { Preferences } from '@/data/documentTypes/Preferences';
@@ -19,6 +31,7 @@ export default function CoefficientsForm({ preferences }: { preferences: Prefere
     initialValues: {
       ...defaultCoefficients,
       ...preferences.coefficients,
+      customCoefficients: preferences.coefficients?.customCoefficients || [],
     },
     validate: {
       nextTag: isPresent,
@@ -31,6 +44,10 @@ export default function CoefficientsForm({ preferences }: { preferences: Prefere
       hasTags: isPresent,
       hasProject: isPresent,
       ageCoefficient: isPresent,
+      customCoefficients: {
+        name: (value) => (value.length < 1 ? 'Required' : null),
+        value: isPresent,
+      },
     },
   });
 
@@ -51,8 +68,36 @@ export default function CoefficientsForm({ preferences }: { preferences: Prefere
   };
 
   const resetToDefaults = () => {
-    form.setValues(defaultCoefficients);
+    form.setValues({ ...defaultCoefficients, customCoefficients: [] });
   };
+
+  const customCoefficientFields = form.values.customCoefficients.map((_item, index) => (
+    <Group key={index} mt="xs">
+      <Select
+        placeholder="Pick value"
+        data={['tag', 'project']}
+        {...form.getInputProps(`customCoefficients.${index}.type`)}
+      />
+      <TextInput
+        placeholder="Name"
+        withAsterisk
+        style={{ flex: 1 }}
+        {...form.getInputProps(`customCoefficients.${index}.name`)}
+      />
+      <NumberInput
+        placeholder="Coefficient"
+        withAsterisk
+        {...form.getInputProps(`customCoefficients.${index}.value`)}
+      />
+      <ActionIcon
+        color="red"
+        onClick={() => form.removeListItem('customCoefficients', index)}
+        aria-label="Delete coefficient"
+      >
+        <IconTrash size="1rem" />
+      </ActionIcon>
+    </Group>
+  ));
 
   return (
     <>
@@ -120,9 +165,29 @@ export default function CoefficientsForm({ preferences }: { preferences: Prefere
               description="Coefficient based on task age in days. Default 2"
             />
           </Stack>
+        </SimpleGrid>
+
+        <Box mt="xl">
+          <Title order={3}>Custom Coefficients</Title>
+          {customCoefficientFields}
+          <Button
+            mt="md"
+            onClick={() =>
+              form.insertListItem('customCoefficients', {
+                type: 'tag',
+                name: '',
+                value: 0,
+              })
+            }
+          >
+            Add Coefficient
+          </Button>
+        </Box>
+
+        <Group mt="xl">
           <Button type="submit">Save Coefficients</Button>
           <Button onClick={resetToDefaults}>Reset to Defaults</Button>
-        </SimpleGrid>
+        </Group>
       </form>
     </>
   );

--- a/src/components/Settings/__tests__/CoefficientsForm.test.tsx
+++ b/src/components/Settings/__tests__/CoefficientsForm.test.tsx
@@ -86,6 +86,51 @@ describe('CoefficientsForm', () => {
     );
   });
 
+  it('Can remove a custom coefficient', async () => {
+    renderWithDataSource(
+      <CoefficientsForm
+        preferences={preferencesFactory({
+          coefficients: {
+            customCoefficients: [{ type: 'tag', name: 'my-tag', value: 123 }],
+          },
+        })}
+      />,
+      getDataSource()
+    );
+
+    const removeButton = screen.getByRole('button', { name: /delete/i });
+    await userEvent.click(removeButton);
+
+    const submitButton = screen.getByRole('button', { name: 'Save Coefficients' });
+    await userEvent.click(submitButton);
+
+    expect(setPreferencesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        coefficients: expect.objectContaining({
+          customCoefficients: [],
+        }),
+      })
+    );
+  });
+
+  it('Validates custom coefficients', async () => {
+    renderWithDataSource(<CoefficientsForm preferences={preferencesFactory()} />, getDataSource());
+
+    const addButton = screen.getByRole('button', { name: 'Add Coefficient' });
+    await userEvent.click(addButton);
+
+    const submitButton = screen.getByRole('button', { name: 'Save Coefficients' });
+    await userEvent.click(submitButton);
+
+    expect(screen.getByText('Required')).toBeInTheDocument();
+
+    const coefficientInput = screen.getByPlaceholderText('Coefficient');
+    await userEvent.clear(coefficientInput);
+    await userEvent.click(submitButton);
+
+    expect(screen.getByText('Must be numeric')).toBeInTheDocument();
+  });
+
   it('Uses default coefficients', async () => {
     renderWithDataSource(<CoefficientsForm preferences={preferencesFactory()} />, getDataSource());
 
@@ -152,5 +197,32 @@ describe('CoefficientsForm', () => {
     // Second click
     await userEvent.click(submitButton);
     expect(setPreferencesMock).toHaveBeenCalledWith(expect.objectContaining({ _rev: 'def-456' }));
+  });
+
+  it('Can add and persist a custom coefficient', async () => {
+    renderWithDataSource(<CoefficientsForm preferences={preferencesFactory()} />, getDataSource());
+
+    const addButton = screen.getByRole('button', { name: 'Add Coefficient' });
+    await userEvent.click(addButton);
+
+    await userEvent.type(screen.getByPlaceholderText('Name'), 'my-tag');
+    await userEvent.type(screen.getByPlaceholderText('Coefficient'), '123');
+
+    const submitButton = screen.getByRole('button', { name: 'Save Coefficients' });
+    await userEvent.click(submitButton);
+
+    expect(setPreferencesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        coefficients: expect.objectContaining({
+          customCoefficients: [
+            {
+              type: 'tag',
+              name: 'my-tag',
+              value: 123,
+            },
+          ],
+        }),
+      })
+    );
   });
 });

--- a/src/data/documentTypes/Preferences.ts
+++ b/src/data/documentTypes/Preferences.ts
@@ -1,6 +1,12 @@
 import { Common } from '@/data/documentTypes/Common';
 import { TaskStatus } from '@/data/documentTypes/Task';
 
+export interface CoefficientRule {
+  type: 'tag' | 'project';
+  name: string;
+  value: number;
+}
+
 export interface Preferences extends Common {
   lastSelectedContext: string;
   lastSelectedStatuses?: TaskStatus[];
@@ -15,6 +21,7 @@ export interface Preferences extends Common {
     hasTags?: number;
     hasProject?: number;
     ageCoefficient?: number;
+    customCoefficients?: CoefficientRule[];
   };
 }
 

--- a/src/helpers/UrgencyCalculator.ts
+++ b/src/helpers/UrgencyCalculator.ts
@@ -1,15 +1,17 @@
-import { Preferences } from '@/data/documentTypes/Preferences';
+import { CoefficientRule, Preferences } from '@/data/documentTypes/Preferences';
 import { Task, TaskPriority, TaskStatus } from '@/data/documentTypes/Task';
 import { BaseCoefficients, defaultCoefficients, getAgeInDays } from '@/helpers/Tasks';
 
 export class UrgencyCalculator {
   private readonly coefficients: BaseCoefficients;
+  private readonly customCoefficients: CoefficientRule[];
 
   constructor(preferences: Preferences) {
     this.coefficients = {
       ...defaultCoefficients,
       ...preferences.coefficients,
     };
+    this.customCoefficients = preferences.coefficients?.customCoefficients || [];
   }
 
   getUrgency(task: Task): number {
@@ -26,6 +28,15 @@ export class UrgencyCalculator {
       task.project ? coefficients.hasProject : 0,
       coefficients.ageCoefficient * (getAgeInDays(task.createdAt) / 365),
     ];
+
+    this.customCoefficients.forEach((rule) => {
+      if (rule.type === 'tag' && task.tags?.includes(rule.name)) {
+        values.push(rule.value);
+      }
+      if (rule.type === 'project' && task.project === rule.name) {
+        values.push(rule.value);
+      }
+    });
 
     return values.reduce((total, value) => total + value, 0);
   }

--- a/src/helpers/__tests__/UrgencyCalculator.test.ts
+++ b/src/helpers/__tests__/UrgencyCalculator.test.ts
@@ -1,0 +1,38 @@
+import { UrgencyCalculator } from '@/helpers/UrgencyCalculator';
+import { preferencesFactory } from '@/test-utils/factories/PreferencesFactory';
+import { taskFactory } from '@/test-utils/factories/TaskFactory';
+
+describe('UrgencyCalculator', () => {
+  it('calculates urgency with custom coefficients', () => {
+    const preferences = preferencesFactory({
+      coefficients: {
+        hasTags: 0,
+        hasProject: 0,
+        mediumPriority: 0,
+        hasDescription: 0,
+        ageCoefficient: 0,
+        customCoefficients: [
+          { type: 'tag', name: 'urgent', value: 100 },
+          { type: 'project', name: 'work', value: 50 },
+        ],
+      },
+    });
+
+    const calculator = new UrgencyCalculator(preferences);
+
+    const taskWithTag = taskFactory({ tags: ['urgent'], project: '', description: '' });
+    const taskWithProject = taskFactory({ project: 'work', tags: [], description: '' });
+    const taskWithBoth = taskFactory({
+      tags: ['urgent'],
+      project: 'work',
+      description: '',
+    });
+    const taskWithNeither = taskFactory({ tags: [], project: '', description: '' });
+
+    // Base urgency is 0 for a new task with no other attributes
+    expect(calculator.getUrgency(taskWithTag)).toBe(100);
+    expect(calculator.getUrgency(taskWithProject)).toBe(50);
+    expect(calculator.getUrgency(taskWithBoth)).toBe(150);
+    expect(calculator.getUrgency(taskWithNeither)).toBe(0);
+  });
+});


### PR DESCRIPTION
This commit introduces a new feature that allows users to define custom coefficients for tags and projects in the urgency calculation.

- Adds a "Custom Coefficients" section to the Coefficients form, allowing users to dynamically add and remove rules.
- Updates the `Preferences` data model to store these custom coefficients.
- Modifies the `UrgencyCalculator` to incorporate the custom coefficients into its calculations.
- Adds comprehensive tests for the new UI components and the updated urgency calculation logic.