### PR TITLE
Fix bug where completedAt is a string

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jonnylist",
   "private": true,
   "type": "module",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -6,7 +6,7 @@ export default function Footer() {
   return (
     <Text size="xs" ta="center" c="gray">
       <Anchor href="https://github.com/jon23d/jonnylist" mr="0.5em">
-        JonnyList 2.0.5
+        JonnyList 2.0.6
       </Anchor>
       © 2025 by
       <Anchor href="https://www.linkedin.com/in/jon23d/" ml="0.5em">

--- a/src/data/TaskRepository.ts
+++ b/src/data/TaskRepository.ts
@@ -133,6 +133,9 @@ export class TaskRepository implements Repository {
       }
       task.createdAt = new Date(task.createdAt);
       task.updatedAt = new Date(task.updatedAt);
+      if (task.completedAt) {
+        task.completedAt = new Date(task.completedAt);
+      }
     });
 
     const filteredTasks = this.filterTasks(allTasks, filter);

--- a/src/data/__tests__/TaskRepository.test.ts
+++ b/src/data/__tests__/TaskRepository.test.ts
@@ -203,6 +203,24 @@ describe('TaskRepository', () => {
     });
   });
 
+  it('Converts completedAt to a date object in getTasks', async () => {
+    const database = getDb();
+    const repository = new TaskRepository(database);
+
+    const task1 = taskFactory({
+      completedAt: new Date(2024, 0, 1),
+      status: TaskStatus.Done,
+    });
+
+    await repository.addTask(task1);
+
+    const tasks = await repository.getTasks({});
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].completedAt).toBeInstanceOf(Date);
+    expect(tasks[0].completedAt?.toISOString()).toBe(new Date(2024, 0, 1).toISOString());
+  });
+
   test('getTasks should return tasks filtered', async () => {
     const database = getDb();
     const repository = new TaskRepository(database);


### PR DESCRIPTION
Tasks live in the database as strings. TaskRepository.getTasks does not convert all date-type fields correctly, having excluded completedAt. This fixes that issue. A future PR should either convert all dates to strings or all strings to dates.